### PR TITLE
Use prefix gateway- in honeycomb span name

### DIFF
--- a/src/main/java/org/commonjava/util/gateway/interceptor/MetricsHandlerInterceptor.java
+++ b/src/main/java/org/commonjava/util/gateway/interceptor/MetricsHandlerInterceptor.java
@@ -84,7 +84,7 @@ public class MetricsHandlerInterceptor
         {
             logger.debug( "Done, item: {}, err: {}", item, err );
             String path = request.path();
-            honeycombManager.startRootTracer( honeycombConfiguration.getFunctionName( path ) ); // function as span name
+            honeycombManager.startRootTracer( "gateway-" + honeycombConfiguration.getFunctionName( path ) ); // gateway-function as span name
             long elapse = currentTimeMillis() - t.get();
             honeycombManager.addFields( elapse, request, item, err );
             honeycombManager.addRootSpanFields();


### PR DESCRIPTION
Gateway will share the dataset with other services in the same environment. So we need to distinguish gateway tracing from others. Adding a prefix to the span name makes it possible.