### PR TITLE
Adding opentracing capabilities to Gateway Service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <quarkus.platform.version>1.9.2.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <o11phant.version>1.3</o11phant.version>
+        <opentracing.version>1.13.3.Final</opentracing.version>
     </properties>
 
     <dependencyManagement>
@@ -87,6 +88,12 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-smallrye-health</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-smallrye-opentracing</artifactId>
+            <version>${opentracing.version}</version>
         </dependency>
 
         <!-- Test -->

--- a/src/main/java/org/commonjava/util/gateway/services/ProxyService.java
+++ b/src/main/java/org/commonjava/util/gateway/services/ProxyService.java
@@ -12,6 +12,7 @@ import org.commonjava.util.gateway.cache.CacheHandler;
 import org.commonjava.util.gateway.config.ProxyConfiguration;
 import org.commonjava.util.gateway.interceptor.ExceptionHandler;
 import org.commonjava.util.gateway.interceptor.MetricsHandler;
+import org.eclipse.microprofile.opentracing.Traced;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +37,7 @@ import static org.commonjava.util.gateway.services.ProxyConstants.EVENT_PROXY_CO
 
 @ApplicationScoped
 @MetricsHandler
+@Traced
 @ExceptionHandler
 public class ProxyService
 {


### PR DESCRIPTION
Adding opentracing to gateway project to be able to capture Proxy Service traces into jaeger instance. Based on requirements on MMENG-1522
https://projects.engineering.redhat.com/browse/MMENG-1522