### PR TITLE
Add forbidden header transfer-encoding

### DIFF
--- a/src/main/java/org/commonjava/util/gateway/services/ProxyConstants.java
+++ b/src/main/java/org/commonjava/util/gateway/services/ProxyConstants.java
@@ -1,7 +1,14 @@
 package org.commonjava.util.gateway.services;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class ProxyConstants
 {
     // Vert.x event types
     public static final String EVENT_PROXY_CONFIG_CHANGE = "proxy-config-change";
+
+    // Auto generated, ignore such upstream headers
+    public static final List<String> FORBIDDEN_HEADERS =
+                    Arrays.asList( "content-length", "connection", "transfer-encoding" );
 }

--- a/src/main/java/org/commonjava/util/gateway/services/ProxyService.java
+++ b/src/main/java/org/commonjava/util/gateway/services/ProxyService.java
@@ -37,6 +37,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.commonjava.o11yphant.metrics.RequestContextConstants.EXTERNAL_ID;
 import static org.commonjava.o11yphant.metrics.RequestContextConstants.TRACE_ID;
 import static org.commonjava.util.gateway.services.ProxyConstants.EVENT_PROXY_CONFIG_CHANGE;
+import static org.commonjava.util.gateway.services.ProxyConstants.FORBIDDEN_HEADERS;
 
 @ApplicationScoped
 @MetricsHandler
@@ -208,7 +209,7 @@ public class ProxyService
             return true;
         }
         String key = header.getKey();
-        return !( key.equalsIgnoreCase( "content-length" ) || key.equalsIgnoreCase( "connection" ) );
+        return !FORBIDDEN_HEADERS.contains( key.toLowerCase() );
     }
 
     private io.vertx.mutiny.core.MultiMap getHeaders( HttpServerRequest request )


### PR DESCRIPTION
Indy add header transfer-encoding and Gateway add such header too. So we got double transfer-encoding header which breaks some tool, e.g, the test suite.
I think it is safe, but we need to test this on stage.