### PR TITLE
Support timeout patterns config

### DIFF
--- a/src/main/java/org/commonjava/util/gateway/config/ProxyConfiguration.java
+++ b/src/main/java/org/commonjava/util/gateway/config/ProxyConfiguration.java
@@ -1,5 +1,6 @@
 package org.commonjava.util.gateway.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.quarkus.runtime.Startup;
 import io.vertx.mutiny.core.eventbus.EventBus;
@@ -20,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
@@ -29,6 +31,7 @@ import java.util.regex.Pattern;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.commonjava.util.gateway.services.ProxyConstants.EVENT_PROXY_CONFIG_CHANGE;
+import static org.commonjava.util.gateway.util.ServiceUtils.parseTimeout;
 
 @Startup
 @ApplicationScoped
@@ -192,6 +195,17 @@ public class ProxyConfiguration
         @JsonProperty( "path-pattern" )
         public String pathPattern;
 
+        @JsonProperty( "read-timeout-patterns" )
+        public String readTimeoutPatterns;
+
+        @JsonIgnore
+        private Map<Pattern, Long> timeoutMap = new HashMap<>();
+
+        public Map<Pattern, Long> getTimeoutMap()
+        {
+            return timeoutMap;
+        }
+
         @Override
         public boolean equals( Object o )
         {
@@ -213,7 +227,8 @@ public class ProxyConfiguration
         public String toString()
         {
             return "ServiceConfig{" + "host='" + host + '\'' + ", port=" + port + ", ssl=" + ssl + ", methods='"
-                            + methods + '\'' + ", cache=" + cache + ", pathPattern='" + pathPattern + '\'' + '}';
+                            + methods + '\'' + ", cache=" + cache + ", pathPattern='" + pathPattern + '\''
+                            + ", readTimeoutPatterns='" + readTimeoutPatterns + '\'' + '}';
         }
 
         private void normalize()
@@ -225,6 +240,23 @@ public class ProxyConfiguration
             if ( cache != null )
             {
                 cache.normalize();
+            }
+            if ( readTimeoutPatterns != null )
+            {
+                final Logger logger = LoggerFactory.getLogger( getClass() );
+                for ( String s : readTimeoutPatterns.split( "," ) )
+                {
+                    if ( isNotBlank( s ) )
+                    {
+                        String[] kv = s.split( "\\|" );
+                        String key = kv[0].trim();
+                        String val = kv[1].trim();
+                        Pattern pattern = Pattern.compile( key );
+                        long t = parseTimeout( val );
+                        timeoutMap.put( pattern, t );
+                        logger.trace( "Add patterned timeout, pattern: {}, timeoutInMillis: {}", key, t );
+                    }
+                }
             }
         }
     }

--- a/src/main/java/org/commonjava/util/gateway/services/ProxyService.java
+++ b/src/main/java/org/commonjava/util/gateway/services/ProxyService.java
@@ -38,6 +38,8 @@ import static org.commonjava.o11yphant.metrics.RequestContextConstants.EXTERNAL_
 import static org.commonjava.o11yphant.metrics.RequestContextConstants.TRACE_ID;
 import static org.commonjava.util.gateway.services.ProxyConstants.EVENT_PROXY_CONFIG_CHANGE;
 import static org.commonjava.util.gateway.services.ProxyConstants.FORBIDDEN_HEADERS;
+import static org.commonjava.util.gateway.util.ServiceUtils.getTimeout;
+import static org.commonjava.util.gateway.util.ServiceUtils.parseTimeout;
 
 @ApplicationScoped
 @MetricsHandler
@@ -46,7 +48,7 @@ public class ProxyService
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    private long DEFAULT_TIMEOUT = TimeUnit.MINUTES.toMillis( 30 ); // default 30 minutes
+    private static long DEFAULT_TIMEOUT = TimeUnit.MINUTES.toMillis( 5 );
 
     private long DEFAULT_BACKOFF_MILLIS = Duration.ofSeconds( 5 ).toMillis();
 
@@ -78,7 +80,7 @@ public class ProxyService
         {
             try
             {
-                t = Duration.parse( "pt" + readTimeout ).toMillis();
+                t = parseTimeout( readTimeout );
             }
             catch ( Exception e )
             {
@@ -100,7 +102,7 @@ public class ProxyService
         return normalizePathAnd( path, p -> classifier.classifyAnd( p, request,
                                                                     (client, service) -> wrapAsyncCall( client.head( p )
                                                                                                    .putHeaders( getHeaders( request ) )
-                                                                                                   .timeout( timeout )
+                                                                                                   .timeout( getTimeout( service, p, timeout ) )
                                                                                                    .send(), request.method() ) ) );
     }
 
@@ -110,7 +112,7 @@ public class ProxyService
                                                                     (client, service) ->
                                                                                     cacheHandler.wrapWithCache( wrapAsyncCall( client.get( p )
                                                                                                    .putHeaders( getHeaders( request ) )
-                                                                                                   .timeout( timeout )
+                                                                                                   .timeout( getTimeout( service, p, timeout ) )
                                                                                                    .send(), request.method() ), p, service ) ) );
     }
 
@@ -121,7 +123,7 @@ public class ProxyService
         return normalizePathAnd( path, p -> classifier.classifyAnd( p, request,
                                                                     (client, service) -> wrapAsyncCall( client.post( p )
                                                                                                    .putHeaders( getHeaders( request ) )
-                                                                                                   .timeout( timeout )
+                                                                                                   .timeout( getTimeout( service, p, timeout ) )
                                                                                                    .sendBuffer( buf ), request.method() ) ) );
     }
 
@@ -132,7 +134,7 @@ public class ProxyService
         return normalizePathAnd( path, p -> classifier.classifyAnd( p, request,
                                                                     (client, service) -> wrapAsyncCall( client.put( p )
                                                                                                    .putHeaders( getHeaders( request ) )
-                                                                                                   .timeout( timeout )
+                                                                                                   .timeout( getTimeout( service, p, timeout ) )
                                                                                                    .sendBuffer( buf ), request.method() ) ) );
     }
 
@@ -141,7 +143,7 @@ public class ProxyService
         return normalizePathAnd( path, p -> classifier.classifyAnd( p, request,
                                                                     (client, service) -> wrapAsyncCall( client.delete( p )
                                                                                                    .putHeaders( getHeaders( request ) )
-                                                                                                   .timeout( timeout )
+                                                                                                   .timeout( getTimeout( service, p, timeout ) )
                                                                                                    .send(), request.method() ) ) );
     }
 

--- a/src/main/java/org/commonjava/util/gateway/util/ServiceUtils.java
+++ b/src/main/java/org/commonjava/util/gateway/util/ServiceUtils.java
@@ -1,0 +1,42 @@
+package org.commonjava.util.gateway.util;
+
+import org.commonjava.util.gateway.config.ProxyConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ServiceUtils
+{
+    private final static Logger logger = LoggerFactory.getLogger( ServiceUtils.class );
+
+    public static long parseTimeout( String timeout )
+    {
+        return Duration.parse( "pt" + timeout ).toMillis();
+    }
+
+    /**
+     * Get timeout according to path patterns, e.g., .+/promote -> 30m, ...
+     */
+    public static long getTimeout( ProxyConfiguration.ServiceConfig serviceConfig, String path, long defaultTimeout )
+    {
+        if ( !serviceConfig.getTimeoutMap().isEmpty() )
+        {
+            //logger.trace( "Check timeout, map:{}", serviceConfig.getTimeoutMap() );
+            for ( Map.Entry<Pattern, Long> et : serviceConfig.getTimeoutMap().entrySet() )
+            {
+                Matcher matcher = et.getKey().matcher( path );
+                if ( matcher.matches() )
+                {
+                    logger.trace( "Get patterned timeout, path:{}, timeout:{}", path, et.getValue() );
+                    return et.getValue();
+                }
+            }
+        }
+        logger.trace( "Return default timeout, path:{}, timeout:{}", path, defaultTimeout );
+        return defaultTimeout;
+    }
+}

--- a/src/main/resources/proxy.yaml
+++ b/src/main/resources/proxy.yaml
@@ -1,5 +1,5 @@
 proxy:
-  read-timeout: 30m
+  read-timeout: 5m
   retry:
     count: 3
     interval: 3000

--- a/src/test/java/org/commonjava/util/gateway/ProxyResourceTest.java
+++ b/src/test/java/org/commonjava/util/gateway/ProxyResourceTest.java
@@ -106,6 +106,15 @@ public class ProxyResourceTest
     }
 
     @Test
+    public void testPromote()
+    {
+        given().when()
+               .post( PROMOTE_PATH )
+               .then()
+               .statusCode( is( 200 ) );
+    }
+
+    @Test
     public void testProxyTimeout()
     {
         given().when()

--- a/src/test/java/org/commonjava/util/gateway/fixture/TestResources.java
+++ b/src/test/java/org/commonjava/util/gateway/fixture/TestResources.java
@@ -66,7 +66,9 @@ public class TestResources
 
     public static final String POST_PATH = "/api/admin/stores/maven/hosted";
 
-    public static final String PROMOTE_TIMEOUT_PATH = "/api/promote/something/really/big";
+    public static final String PROMOTE_TIMEOUT_PATH = "/api/other/really/big/promote";
+
+    public static final String PROMOTE_PATH = "/api/promote";
 
     public static final String EXCEPTION_PATH = "/api/content/maven/hosted/local-deployments/exception";
 
@@ -103,6 +105,8 @@ public class TestResources
         wireMockServer.stubFor( put( LARGE_FILE_PATH ).willReturn( aResponse().withStatus( 201 ) ) );
 
         wireMockServer.stubFor( post( LARGE_FILE_PATH ).willReturn( aResponse().withStatus( 201 ) ));
+
+        wireMockServer.stubFor( post( PROMOTE_PATH ).willReturn( aResponse().withFixedDelay( 1500 ).withStatus( 200 ) ) );
 
         wireMockServer.stubFor( post( PROMOTE_TIMEOUT_PATH ).willReturn( aResponse().withFixedDelay( 3000 ).withStatus( 200 ) ) );
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,31 @@
+# Quarkus will choose application.yaml over application.properties.
+quarkus:
+    http:
+        port: 8080
+        read-timeout: 30m
+        limits:
+          max-body-size: 500M
+
+    package:
+        uber-jar: true
+
+    # Logging (disable console on prod)
+    log:
+        level: INFO
+        category:
+            "org.commonjava.util.gateway":
+                level: TRACE
+        console:
+            level: TRACE
+            enable: true
+        file:
+            enable: true
+            path: "log/gateway.log"
+            level: DEBUG
+            format: "%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n"
+            rotation:
+                max-backup-index: 5
+                max-file-size: 10M
+
+    swagger-ui:
+        always-include: true

--- a/src/test/resources/proxy.yaml
+++ b/src/test/resources/proxy.yaml
@@ -7,7 +7,8 @@ proxy:
   services:
     - host: localhost
       port: 9090
-      path-pattern: "/api/(content|admin|promote)/.+"
+      path-pattern: "/api/(content|admin|promote|other).*"
+      read-timeout-patterns: ".+/promote|2s"
       cache:
         enabled: true
         readonly: false


### PR DESCRIPTION
Use read-timeout-patterns in service config to override the default timeout. E.g., we can set 30m for promotions, as read-timeout-patterns: ".+/promote|30m".