### PR TITLE
Not use default content-type

### DIFF
--- a/src/main/java/org/commonjava/util/gateway/util/WebClientAdapter.java
+++ b/src/main/java/org/commonjava/util/gateway/util/WebClientAdapter.java
@@ -111,13 +111,7 @@ public class WebClientAdapter
 
     private String getContentType( HttpServerRequest req )
     {
-        String contentType = req.getHeader( "Content-Type" );
-        if ( contentType == null )
-        {
-            contentType = "application/octet-stream";
-        }
-
-        return contentType;
+        return req.getHeader( "Content-Type" );
     }
 
     private File cacheInputStream( InputStream is ) throws IOException


### PR DESCRIPTION
When testing the new code, I hit error like:
[ERROR] [PUT /admin/stores/maven/hosted/build-test-97066] Unhandled exception: Cannot consume content type javax.ws.rs.NotSupportedException: Cannot consume content type

This is because the endpoint can not consume "application/octet-stream". 
Indy can handle requests without a content-type very well. And Indy client use put.setEntity( new StringEntity( objectMapper.writeValueAsString( obj ) ) ); and not set the content-type either. 

I check the javadoc; the MediaType in RequestBody.create() is @Nullable. I think we can safely fix it by not setting default content-type.