### PR TITLE
Enable the otlp build-time locked property

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,7 +7,7 @@ quarkus:
           max-body-size: 500M
 
     opentelemetry:
-        enabled: false
+        enabled: true
         tracer:
             exporter:
                 otlp:


### PR DESCRIPTION
Tracing now will be always disabled for gateway since otlp was disabled locked at build-time.
If we want to enable the traces like on indy-gateway-master, we need to change this to be enabled at build-time.
If we have other gateway instance that we don't want to enable trace, the honeycomb headers in configmap will be concealed(based on template value: trace_enabled and trace_tracer), which is equivalent to disabling.