### PR TITLE
Add otlp traces sampler support

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,11 @@ quarkus:
     opentelemetry:
         enabled: true
         tracer:
+            enabled: true
+            # reflect sampling on collector
+            resource-attributes: sampler_ratio=0.05
+            sampler:
+                ratio: 0.05
             exporter:
                 otlp:
                     # This is for sending to something like opentelemetry-collector


### PR DESCRIPTION
I searched a lot about the opentelemetry sdk, it doesn’t seem to support the dynamic sampling like honeycomb, so we could just scale the deterministic sampling.
And for quarkus otel sdk, it has the built-in sampler through setting the desired sampler config, we could configure the TraceIdRatioBased which is associated with the above.