### PR TITLE
Close previous response when retrying

### DIFF
--- a/src/main/java/org/commonjava/util/gateway/util/WebClientAdapter.java
+++ b/src/main/java/org/commonjava/util/gateway/util/WebClientAdapter.java
@@ -389,9 +389,15 @@ public class WebClientAdapter
         public Response intercept( @NotNull Chain chain ) throws IOException
         {
             Request req = chain.request();
-            Response resp;
+            Response resp = null;
             int tryCounter = 0;
             do {
+                if ( resp != null )
+                {
+                    // We will get java.lang.IllegalStateException if the previous response is still open for
+                    // whatever reason when retrying
+                    resp.close();
+                }
                 try
                 {
                     resp = chain.proceed( req );


### PR DESCRIPTION
This is for [MMENG-2775](https://issues.redhat.com/browse/MMENG-2775)
We should close the prev response before retry. Otherwise we will get 

> Exception in thread "OkHttp Dispatcher" java.lang.IllegalStateException: cannot make a new request because the previous response is still open: please call response.close()
	...
	at org.commonjava.util.gateway.util.WebClientAdapter$RetryInterceptor.intercept(WebClientAdapter.java:397)