### PR TITLE
Ensure that span generation is null safe.

### DIFF
--- a/src/main/java/org/commonjava/util/gateway/cache/CacheHandler.java
+++ b/src/main/java/org/commonjava/util/gateway/cache/CacheHandler.java
@@ -44,37 +44,25 @@ public class CacheHandler
         CacheConfiguration cache = service.cache;
         if ( cache == null )
         {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "cached", 0 );
-            }
+            Span.current().setAttribute( "cached", 0 );
 
             logger.trace( "No cache defined" );
             return uni;
         }
 
-        if ( otel.enabled() )
-        {
-            Span.current().setAttribute( "cache_strategy", cache.strategy );
-        }
+        Span.current().setAttribute( "cache_strategy", cache.strategy );
 
         CacheStrategy cacheStrategy = getCacheStrategy( cache.strategy );
         if ( cacheStrategy.isCache( cache, path ) )
         {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "cached", 1 );
-            }
+            Span.current().setAttribute( "cached", 1 );
 
             File cached = cacheStrategy.getCachedFile( cache, path );
             String absolutePath = cached.getAbsolutePath();
             logger.trace( "Search cache, file: {}", absolutePath );
             if ( cached.exists() )
             {
-                if ( otel.enabled() )
-                {
-                    Span.current().setAttribute( "served_from", "cache" );
-                }
+                Span.current().setAttribute( "served_from", "cache" );
 
                 logger.debug( "Found file in cache, file: {}", absolutePath );
                 Uni<Response> ret = null;
@@ -95,11 +83,8 @@ public class CacheHandler
 
         if ( cacheStrategy.isCacheForWrite( cache, path ) )
         {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "cached", 1 );
-                Span.current().setAttribute( "served_from", "proxy" );
-            }
+            Span.current().setAttribute( "cached", 1 );
+            Span.current().setAttribute( "served_from", "proxy" );
 
             uni = uni.onItem().invoke( resp -> {
                 Object entity = resp.getEntity();
@@ -150,10 +135,7 @@ public class CacheHandler
     private Uni<Response> renderFile( File cached ) throws IOException
     {
         logger.debug( "Render file, {}", cached.getPath() );
-        if ( otel.enabled() )
-        {
-            Span.current().setAttribute( "response.content_length", cached.length() );
-        }
+        Span.current().setAttribute( "response.content_length", cached.length() );
 
         Response.ResponseBuilder resp = Response.ok( cached );
         File httpMetadata = getMetadataFile( cached );

--- a/src/main/java/org/commonjava/util/gateway/services/Classifier.java
+++ b/src/main/java/org/commonjava/util/gateway/services/Classifier.java
@@ -80,36 +80,26 @@ public class Classifier
     public <R> R classifyAnd( String path, HttpServerRequest request,
                               BiFunction<WebClientAdapter, ServiceConfig, R> action ) throws Exception
     {
-        if ( otel.enabled() )
-        {
-            Span span = Span.current();
-            span.setAttribute( "service_name", "gateway" );
-            span.setAttribute( "name", request.method().name() );
-            span.setAttribute( "path.ext", FilenameUtils.getExtension( path ) );
-        }
+        Span span = Span.current();
+        span.setAttribute( "service_name", "gateway" );
+        span.setAttribute( "name", request.method().name() );
+        span.setAttribute( "path.ext", FilenameUtils.getExtension( path ) );
 
         ServiceConfig service = getServiceConfig( path, request );
         if ( service == null )
         {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "serviced", 0 );
-                Span.current().setAttribute( "missing.path", path );
-                Span.current().setAttribute( "missing.method", request.method().name() );
-            }
+            span.setAttribute( "serviced", 0 );
+            span.setAttribute( "missing.path", path );
+            span.setAttribute( "missing.method", request.method().name() );
 
             throw new ServiceNotFoundException( "Service not found, path: " + path + ", method: " + request.method() );
         }
 
-        if ( otel.enabled() )
-        {
-            Span span = Span.current();
-            Span.current().setAttribute( "serviced", 1 );
-            span.setAttribute( "target.host", service.host );
-            span.setAttribute( "target.port", service.port );
-            span.setAttribute( "target.method", request.method().name() );
-            span.setAttribute( "target.path", path );
-        }
+        span.setAttribute( "serviced", 1 );
+        span.setAttribute( "target.host", service.host );
+        span.setAttribute( "target.port", service.port );
+        span.setAttribute( "target.method", request.method().name() );
+        span.setAttribute( "target.path", path );
 
         return action.apply( getWebClient( service ), service );
     }

--- a/src/main/java/org/commonjava/util/gateway/util/ProxyStreamingOutput.java
+++ b/src/main/java/org/commonjava/util/gateway/util/ProxyStreamingOutput.java
@@ -53,10 +53,7 @@ public class ProxyStreamingOutput
                 logger.trace( "Copying from: {} to: {}", bodyStream, out );
                 IOUtils.copy( bodyStream, out );
 
-                if ( otel.enabled() )
-                {
-                    Span.current().setAttribute( "response.content_length", cout.getByteCount() );
-                }
+                Span.current().setAttribute( "response.content_length", cout.getByteCount() );
 
             }
             finally
@@ -67,10 +64,7 @@ public class ProxyStreamingOutput
         }
         else
         {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "response.content_length", 0 );
-            }
+            Span.current().setAttribute( "response.content_length", 0 );
         }
     }
 
@@ -87,11 +81,8 @@ public class ProxyStreamingOutput
         }
         catch ( IOException e )
         {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "body.ignored_error_class", e.getClass().getSimpleName() );
-                Span.current().setAttribute( "body.ignored_error_class", e.getMessage() );
-            }
+            Span.current().setAttribute( "body.ignored_error_class", e.getClass().getSimpleName() );
+            Span.current().setAttribute( "body.ignored_error_class", e.getMessage() );
 
             logger.trace( "Failed to close body stream in proxy response.", e );
         }
@@ -111,11 +102,8 @@ public class ProxyStreamingOutput
         }
         catch ( IOException e )
         {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "cache.ignored_error_class", e.getClass().getSimpleName() );
-                Span.current().setAttribute( "cache.ignored_error_class", e.getMessage() );
-            }
+            Span.current().setAttribute( "cache.ignored_error_class", e.getClass().getSimpleName() );
+            Span.current().setAttribute( "cache.ignored_error_class", e.getMessage() );
 
             logger.trace( "Failed to close cache stream in proxy response.", e );
         }

--- a/src/test/java/org/commonjava/util/gateway/util/OtelAdapterTest.java
+++ b/src/test/java/org/commonjava/util/gateway/util/OtelAdapterTest.java
@@ -1,0 +1,45 @@
+package org.commonjava.util.gateway.util;
+
+import io.opentelemetry.api.trace.Span;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class OtelAdapterTest {
+    OtelAdapter otelAdapter;
+
+    @BeforeEach
+    void setUp() {
+        otelAdapter = new OtelAdapter();
+    }
+
+    @Test
+    void shouldReturnNoopSpanWhenDisabled() {
+        //Given
+        otelAdapter.enabled = false;
+
+        //When
+        final Span clientSpan = otelAdapter.newClientSpan("test-adapter", "disabledTest");
+
+        //Then
+        assertThat(clientSpan.isRecording(), is(false));
+    }
+
+    @Test
+    void shouldReturnPropagatableSpanWhenDisabled() {
+        //Given
+        otelAdapter.enabled = true;
+
+        //When
+        final Span clientSpan = otelAdapter.newClientSpan("test-adapter", "disabledTest");
+
+        //Then
+        assertThat(clientSpan.isRecording(), is(true));
+        assertThat(clientSpan.getSpanContext().getSpanId(), notNullValue(String.class));
+    }
+}


### PR DESCRIPTION
Open Telemetry is quite explicit about avoiding the need for `null`/`nil` checking of its API's see: https://opentelemetry.io/docs/reference/specification/trace/api/#behavior-of-the-api-in-the-absence-of-an-installed-sdk so we should continue that into the OtelAdapter.