### PR TITLE
Update log lever for retry

### DIFF
--- a/src/main/java/org/commonjava/util/gateway/util/WebClientAdapter.java
+++ b/src/main/java/org/commonjava/util/gateway/util/WebClientAdapter.java
@@ -410,7 +410,7 @@ public class WebClientAdapter
                             Span.current()
                                 .setAttribute( "target.try." + tryCounter + ".status_code", resp.code() );
 
-                            logger.debug( "TRY({}/{}): Response missing or indicates server error: {}. Retrying",
+                            logger.warn( "TRY({}/{}): Response missing or indicates server error: {}. Retrying",
                                           tryCounter, count, resp );
                         }
                     }
@@ -426,7 +426,7 @@ public class WebClientAdapter
                     Span.current()
                         .setAttribute( "target.try." + tryCounter + ".error_class", e.getClass().getSimpleName() );
 
-                    logger.debug( "TRY(" + tryCounter + "/" + count + "): Failed upstream request: " + req.url(), e );
+                    logger.warn( "TRY(" + tryCounter + "/" + count + "): Failed upstream request: " + req.url(), e );
                 }
 
                 try


### PR DESCRIPTION
This if for [MMENG-4192](https://issues.redhat.com/browse/MMENG-4192) Improve the response from gateway.

The error "java.io.IOException: Proxy retry interceptor reached an unexpected fall-through condition!" is because the retry counter reached the limit. This pr update the log level from debug to warn before retry fails so we can easily check the real error.